### PR TITLE
Bug Fix 1

### DIFF
--- a/src/Global/RatingStar.jsx
+++ b/src/Global/RatingStar.jsx
@@ -1,16 +1,19 @@
-import { Link } from 'react-router-dom';
-
 const RatingStar = ({ venue }) => {
+  const rating =
+    venue.rating && Number.isInteger(venue.rating) && venue.rating <= 5
+      ? venue.rating
+      : 0;
+
   return (
     <div className="my-2">
-      {venue.rating >= 1 ? (
+      {rating >= 1 ? (
         <p className="font-body text-md font-light">
-          {[...Array(venue.rating)].map((_, i) => (
+          {[...Array(rating)].map((_, i) => (
             <span className="text-second" key={i}>
               ★
             </span>
           ))}
-          {[...Array(5 - Math.round(venue.rating))].map((_, i) => (
+          {[...Array(5 - Math.round(rating))].map((_, i) => (
             <span className="text-blue" key={i}>
               ☆
             </span>


### PR DESCRIPTION
Fixing RangeError in RatingStar Component

This PR addresses a RangeError encountered in the RatingStar component, which was being triggered when attempting to create an array of invalid length. The error was potentially caused by non-integer, null, or undefined values for venue.rating, or values greater than 5.

The solution involves validating the venue.rating value before using it to create an array. If the rating value is an integer, is not null, and is less than or equal to 5, we use it to generate the array. If it doesn't meet these conditions, we set it to 0 to ensure safe operation and avoid any RangeErrors.

This fix improves the reliability and robustness of the RatingStar component, enabling it to handle inconsistent rating data more effectively.