### PR TITLE
fix for how the profile is displayed if the user is not manger

### DIFF
--- a/src/Pages/Profile/Profile.jsx
+++ b/src/Pages/Profile/Profile.jsx
@@ -8,6 +8,7 @@ import AddAccommodationForm from './CreateAccommodation/AddAccommodationForm';
 import Helper from './Helper';
 import SecondHelper from './SecondHelper';
 import UserBookings from './UserBookings';
+import HelperNoManger from './HelperNoManger';
 import RentOuts from './RentOuts';
 import BreadCrumbs from '../../Global/BreadCrumbs';
 import SpinnerComponent from '../../Global/SpinnerComponent';
@@ -25,6 +26,7 @@ const Profile = () => {
   const [showRentOuts, setShowRentOuts] = useState(false);
   const isLoading = useSelector((state) => state.loader.isLoading);
 
+  console.log(userDetails.manager);
   const breadcrumb = [
     { name: 'Home', path: '/' },
     { name: 'Profile', path: '/Profile' },
@@ -106,12 +108,17 @@ const Profile = () => {
           {showRentOuts && <RentOuts onCancel={handleCancelRentOuts} />}
           {!showAddAccommodationForm && !showUserBookings && !showRentOuts && (
             <>
-              <div className="m-2">
-                <AddAccommodation userName={userName} />
-              </div>
-              <div className="m-2">
-                <Helper />
-              </div>
+              {userDetails.manager === true && (
+                <div className="m-2">
+                  <AddAccommodation />
+                </div>
+              )}
+
+              {userDetails.manager === true && (
+                <div className="m-2">
+                  <Helper />
+                </div>
+              )}
               <div className="m-2">
                 <SecondHelper />
               </div>


### PR DESCRIPTION
I have enhanced the profile page by removing certain features specifically designed for managers, when the user is not a manager. This modification ensures a more streamlined and user-friendly experience, tailored to the specific needs of each user. By eliminating unnecessary elements, the profile page becomes optimized and more efficient for users who do not require manager-related functionalities